### PR TITLE
Add and configure eslint-plugin-eslint-comments

### DIFF
--- a/packages/eslint-config-cos-base/index.js
+++ b/packages/eslint-config-cos-base/index.js
@@ -3,7 +3,9 @@ module.exports = {
         'airbnb-base',
     ],
     parser: 'babel-eslint',
-    plugins: [],
+    plugins: [
+        'eslint-comments',
+    ],
     rules: {
         // We're a Python shop
         indent: ['error', 4],
@@ -40,6 +42,24 @@ module.exports = {
 
         // Warn for now
         'max-len': 'warn',
+
+        // ESLint comments
+        'eslint-comments/disable-enable-pair': 'error',
+        'eslint-comments/no-duplicate-disable': 'error',
+        'eslint-comments/no-unlimited-disable': 'error',
+        'eslint-comments/no-unused-disable': 'error',
+        'eslint-comments/no-unused-enable': 'error',
+        'eslint-comments/no-use': [
+            'error',
+            {
+                allow: [
+                    'eslint-disable',
+                    'eslint-disable-line',
+                    'eslint-disable-next-line',
+                    'eslint-enable',
+                ],
+            },
+        ],
     },
     settings: {
         'import/external-module-folders': [

--- a/packages/eslint-config-cos-base/package.json
+++ b/packages/eslint-config-cos-base/package.json
@@ -33,6 +33,7 @@
   "dependencies": {
     "babel-eslint": "^7.2.3",
     "eslint-config-airbnb-base": "^11.1.3",
+    "eslint-plugin-eslint-comments": "^1.0.0",
     "eslint-plugin-import": "^2.2.0"
   },
   "devDependencies": {

--- a/packages/eslint-config-cos-base/yarn.lock
+++ b/packages/eslint-config-cos-base/yarn.lock
@@ -333,6 +333,12 @@ eslint-module-utils@^2.0.0:
     debug "2.2.0"
     pkg-dir "^1.0.0"
 
+eslint-plugin-eslint-comments@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-eslint-comments/-/eslint-plugin-eslint-comments-1.0.0.tgz#e36743d1b2c9389e6d484846a5b46d9ade36d69e"
+  dependencies:
+    escape-string-regexp "^1.0.5"
+
 eslint-plugin-import@^2.2.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/eslint-plugin-import/-/eslint-plugin-import-2.2.0.tgz#72ba306fad305d67c4816348a4699a4229ac8b4e"


### PR DESCRIPTION
Add plugin for ESLint comments to help those wishing to **sparingly** disable rules, do so in a safe way.